### PR TITLE
Fixade så att det inte är dubletter av kartan när man skriver look

### DIFF
--- a/PowerFightersXmas/PowerFightersXmas/Logic/CommandHandler.cs
+++ b/PowerFightersXmas/PowerFightersXmas/Logic/CommandHandler.cs
@@ -35,7 +35,7 @@ namespace PowerFightersXmas.Logic
                     break;
 
                 case "look":
-                    _gameState.ShowState();
+                    // Behövs ingen utskrift eftersom att ShowState() redan skrivs ut!
                     break;
 
                 case "take":


### PR DESCRIPTION
## Sammanfattning av Sourcery

Felkorrigeringar:
- Förhindra duplicerad utskrift av spelets tillstånd när spelaren använder "look"-kommandot.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent duplicate printing of the game state when the player uses the "look" command.

</details>